### PR TITLE
fix: should init candyClockStyle and  candyDotStyle with empty strings

### DIFF
--- a/stylesheets.js
+++ b/stylesheets.js
@@ -1265,7 +1265,7 @@ function saveStylesheet(obar, Me) {
 
     // Candybar style 
     let candyalpha = obar._settings.get_double('candyalpha');
-    let candyStyleArr = [], candyHighlightArr = [], candyDotStyle, candyClockStyle;
+    let candyStyleArr = [], candyHighlightArr = [], candyDotStyle = '', candyClockStyle = '';
     let hgCandy = [hred, hgreen, hblue];
     for(let i=1; i<=16; i++) {
         let candyColor = obar._settings.get_strv('candy'+i);


### PR DESCRIPTION
Hi @neuromorph.

After the recent update, the extension failed to load. From the error message, I noticed it was because the `stylesheet.css` became invalid.

Luckily, the issue was easy to be solved. The variable `candyClockStyle` and `candyDotStyle` should be initialized as empty strings. Otherwise, `undefined` will be filled in the stylesheet, which makes it invalid.

Please take a look and tell me if there's something I missed.
Thank You.